### PR TITLE
CONFIG_TO_NUMBER_ fix

### DIFF
--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -55,12 +55,12 @@ CONFIG_TO_NUMBER_JKU = {
     CONFIG6: [1, 5, 9, 13, 17, 21],
 }
 
-#all short shots, 50x50 only
+# all short shots, 50x50 only
 CONFIG_TO_NUMBER_UOB = {
-    CONFIG6: [1, 5, 9, 13, 17, 21], #7 short shot
-    CONFIG5: [2, 6, 10, 14, 18, 22], #5 short shot
-    CONFIG2: [3, 7, 11, 15, 19, 23], #3 short shot
-
+    CONFIG6: [1, 5, 9, 13, 17, 21],  # 7 short shot
+    CONFIG5: [2, 6, 10, 14, 18, 22],  # 5 short shot
+    CONFIG2: [3, 7, 11, 15, 19, 23],  # 3 short shot
+}
 NUMBER_TO_CONFIG_KIT = {v: k for k, values in CONFIG_TO_NUMBER_KIT.items() for v in values}
 NUMBER_TO_CONFIG_JKU = {v: k for k, values in CONFIG_TO_NUMBER_JKU.items() for v in values}
 NUMBER_TO_CONFIG_UOB = {v: k for k, values in CONFIG_TO_NUMBER_UOB.items() for v in values}
@@ -137,7 +137,7 @@ def read(institution, folder):
             else:
                 specification = NUMBER_TO_CONFIG_KIT[int(number)]
         except KeyError:
-            print(f'Material {material} file number {int(number)} is not in CONFIG_TO_NUMBER_')
+            print(f"Material {material} file number {int(number)} is not in CONFIG_TO_NUMBER_")
         if specification not in all_data[material]:
             all_data[material][specification] = []
         all_data[material][specification].append(pd_data)

--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -55,8 +55,15 @@ CONFIG_TO_NUMBER_JKU = {
     CONFIG6: [1, 5, 9, 13, 17, 21],
 }
 
+#all short shots, 50x50 only
+CONFIG_TO_NUMBER_UOB = {
+    CONFIG6: [1, 5, 9, 13, 17, 21], #7 short shot
+    CONFIG5: [2, 6, 10, 14, 18, 22], #5 short shot
+    CONFIG2: [3, 7, 11, 15, 19, 23], #3 short shot
+
 NUMBER_TO_CONFIG_KIT = {v: k for k, values in CONFIG_TO_NUMBER_KIT.items() for v in values}
 NUMBER_TO_CONFIG_JKU = {v: k for k, values in CONFIG_TO_NUMBER_JKU.items() for v in values}
+NUMBER_TO_CONFIG_UOB = {v: k for k, values in CONFIG_TO_NUMBER_UOB.items() for v in values}
 
 # File extensions of the data files
 FILE_EXTENSION = {

--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -129,10 +129,15 @@ def read(institution, folder):
         if material not in all_data:
             all_data[material] = {}
         # Determine the specification based on the institution
-        if institution == JKU:
-            specification = NUMBER_TO_CONFIG_JKU[int(number)]
-        else:
-            specification = NUMBER_TO_CONFIG_KIT[int(number)]
+        try:
+            if institution == JKU:
+                specification = NUMBER_TO_CONFIG_JKU[int(number)]
+            elif institution == UOB:
+                specification = NUMBER_TO_CONFIG_UOB[int(number)]
+            else:
+                specification = NUMBER_TO_CONFIG_KIT[int(number)]
+        except KeyError:
+            print(f'Material {material} file number {int(number)} is not in CONFIG_TO_NUMBER_')
         if specification not in all_data[material]:
             all_data[material][specification] = []
         all_data[material][specification].append(pd_data)


### PR DESCRIPTION
I added CONFIG_TO_NUMBER_ which includes 7,5,3 short shots for 50x50 specimens only

The original version CONFIG_TO_NUMBER_KIT (for everyone apart from JKU) which included 100x100 specimens which could cause incorrect csv file number

Anatoly Koptelov, UoB

