### PR TITLE
Skipped additional row in _read_utw so it works on all files

### DIFF
--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -178,7 +178,7 @@ def _read_kit(file):
 
 def _read_utw(file):
     """Read UT/TPRC data file."""
-    data = pd.read_csv(file, sep=",", names=UTW_NAMING, skiprows=6, quotechar='"')
+    data = pd.read_csv(file, sep=",", names=UTW_NAMING, skiprows=7, quotechar='"')
     data[GAP] = -data[GAP]
     data[DISPLACEMENT] = data[GAP][0] - data[GAP]
     return data


### PR DESCRIPTION
Updated `_read_utw(file)` because some files had a longer header... Now it works on all files, though it does skip the first data point in many files. This, however, is not a practical problem as in many cases the test has barely started.