### PR TITLE
Update read function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E203, E266, E501, W503, C901, E741, D104, E231
-max-line-length = 100
-max-complexity = 18
-select = B,C,D,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
 # Pre-commit itself
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,20 +10,14 @@ repos:
     -   id: check-added-large-files
         args:
         - --maxkb=5000
-# Black code style formatter
--   repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-# isort import sorting
--   repo: https://github.com/timothycrosley/isort
-    rev: '6.0.1'
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-# Flake8 for linting
--   repo: https://github.com/PyCQA/flake8
-    rev: '7.2.0'
-    hooks:
-    -   id: flake8
-        additional_dependencies: [flake8-docstrings, future-fstrings]
+# Ruff linter and formatter
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.13.1
+  hooks:
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      types_or: [ python, pyi, jupyter ]

--- a/example/plot_force_gap.py
+++ b/example/plot_force_gap.py
@@ -18,9 +18,7 @@ folder = pl.Path("Path/to/data")
 # - all data
 data = read(institution, folder)
 # - specific material and/or specification
-# data = read(
-#     institution, folder, mat_of_interest="CF5050K", spec_of_interest="7mm 100x100"
-# )
+# data = read(institution, folder, mat_of_interest="CF5050K", spec_of_interest="3mm 100x100")
 
 # Log the loaded data to the console
 print_data_structure(data)
@@ -42,7 +40,7 @@ plot_mean_std = True  # plot mean and std of the specification
 for material, configs in data.items():
     for config, experiments in configs.items():
         min_gap = next((v for k, v in min_gap_map.items() if k in config), min_gap_wildcard)
-        experiments_cropped = crop_to_range(experiments, min_gap, max_gap, x_name, True)
+        experiments_cropped = crop_to_range(experiments.values(), min_gap, max_gap, x_name, True)
         # Initialize figure
         fig, ax = plt.subplots(1, 1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ dependencies = ["numpy", "pandas", "scipy", "matplotlib"]
 [tool.distutils.bdist_wheel]
 universal = true
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 line-length = 100
 lint.extend-select = [
@@ -48,10 +45,7 @@ lint.extend-select = [
   "NPY", # NumPy
   "RUF", # Ruff
 ]
-lint.ignore = ["PD901"]  # ignore generic name `df` for DataFrame
-
-[tool.isort]
-profile = "black"
+lint.ignore = ["PD901"] # ignore generic name `df` for DataFrame
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration

--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -99,7 +99,14 @@ FILE_EXTENSION = {
 }
 
 
-def read(institution, folder, mat_of_interest=None, spec_of_interest=None):
+def read(
+    institution,
+    folder,
+    mat_of_interest=None,
+    spec_of_interest=None,
+    skip_erroneous_files=True,
+    verbose=True,
+):
     """Read test data.
 
     Parameters
@@ -112,23 +119,44 @@ def read(institution, folder, mat_of_interest=None, spec_of_interest=None):
         Material of interest, e.g., 'CF5050K'. If None, all materials are read.
     spec_of_interest : str | None
         Specification of interest, e.g., '3mm 100x100'. If None, all specifications are read.
+    skip_erroneous_files : bool
+        If True, skip files listed in error.log located in the folder.
+        Error log format: one erroneous filename per line, followed by a colon and the error
+        message. An exemplary error log ::
+
+            sample1.csv: Error message
+            sample2.csv: Another error message
+
+    verbose : bool
+        If True, print information about the reading process.
 
     Returns
     -------
-    dict[str, dict[str, list[pd.DataFrame]]]
+    dict[str, dict[str, dict[pd.DataFrame]]]
         Dictionary containing the experimental data.
     """
     folder = pl.Path(folder)
-    print(folder)
     if not folder.exists():
         raise FileNotFoundError(f"Folder not found: {folder}")
+
+    # Check for errorneous files
+    error_log_file = folder / "error.log"
+    if skip_erroneous_files and error_log_file.exists():
+        erroneous_files = _read_error_log(error_log_file)
+    else:
+        erroneous_files = []
 
     # Read data
     all_data = {}
     files = list(folder.glob(FILE_EXTENSION[institution]))  # Generator in Liste umwandeln
-    print(f"📁 Total number of {institution} data files: {len(files)}")
+    if verbose:
+        print(f"📁 Total number of {institution} data files: {len(files)}")
     n_files_read = 0
     for file in folder.glob(FILE_EXTENSION[institution]):
+        if file.name.lower() in erroneous_files:
+            if verbose:
+                print(f"Skipping erroneous file: {file.name}")
+            continue
         _, material, number = decode_filename(file.stem)
 
         # Determine the specification based on the institution
@@ -185,10 +213,11 @@ def read(institution, folder, mat_of_interest=None, spec_of_interest=None):
 
         # Add specification to all data
         if specification not in all_data[material]:
-            all_data[material][specification] = []
-        all_data[material][specification].append(pd_data)
+            all_data[material][specification] = {}
+        all_data[material][specification][int(number)] = pd_data
         n_files_read += 1
-    print(f"... loaded {n_files_read} {institution} data files.")
+    if verbose:
+        print(f"... loaded {n_files_read} {institution} data files.")
     return all_data
 
 
@@ -274,3 +303,42 @@ def _read_ivw(file):
     )
     data[FORCE] *= 1_000  # Convert kN to N
     return data
+
+
+def _read_error_log(file):
+    """Read error log and return a list of erroneous files (lowercase)."""
+    erroneous_files = []
+
+    try:
+        with file.open("r") as f:
+            lines = f.readlines()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"Warning: Could not read error log {file.as_posix()}: {e}")
+        return erroneous_files
+
+    for line_num, line in enumerate(lines, start=1):
+        # Check formatting
+        if ":" not in line:
+            print(
+                f"Warning: Malformed line {line_num} in error log {file.as_posix()}: "
+                f"'{line.strip()}'"
+            )
+            continue
+
+        # Extract filename
+        try:
+            filename = line.split(":")[0].strip()
+            if filename:
+                erroneous_files.append(filename.lower())
+            else:
+                print(
+                    f"Warning: Line {line_num} in error log {file.as_posix()} has empty filename: "
+                    f"{line}"
+                )
+        except Exception as e:
+            print(
+                f"Warning: Could not parse line {line_num} in error log {file.as_posix()}: "
+                f"{line} - {e}"
+            )
+            continue
+    return erroneous_files

--- a/src/smc_benchmark/read.py
+++ b/src/smc_benchmark/read.py
@@ -132,7 +132,7 @@ def read(
 
     Returns
     -------
-    dict[str, dict[str, dict[pd.DataFrame]]]
+    dict[str, dict[str, dict[int, pd.DataFrame]]]
         Dictionary containing the experimental data.
     """
     folder = pl.Path(folder)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -41,10 +41,11 @@ def test_read_institution(institution, file):
     for exp, spec_dict in data.items():
         assert isinstance(exp, str)
         assert isinstance(spec_dict, dict)
-        for name, values in spec_dict.items():
+        for name, experiments in spec_dict.items():
             assert isinstance(name, str)
-            assert isinstance(values, list)
-            assert all(isinstance(p, pd.DataFrame) for p in values)
+            for id_i, df_i in experiments.items():
+                assert isinstance(id_i, int)
+                assert isinstance(df_i, pd.DataFrame)
 
 
 @pt.mark.parametrize("institution, file", testdata)
@@ -62,8 +63,8 @@ def test_plotting(institution, file, dir_results):
     # Plot all configurations
     for material, configs in data.items():
         for config, experiments in configs.items():
-            fig, ax = plt.subplots(1, 1)
-            for experiment in experiments:
+            _, ax = plt.subplots(1, 1)
+            for experiment in experiments.values():
                 ax.plot(experiment[DISPLACEMENT], experiment[FORCE])
             ax.set_xlabel("Displacement in mm")
             ax.set_ylabel("Force in N")


### PR DESCRIPTION
The following updates to the `read()` function have been introduced:

- Return `dict[str, dict[str, dict[int, pd.DataFrame]]]` instead of `dict[str, dict[str, list[pd.DataFrame]]]` to also keep track of the experiment number.
- Add option to skip experiments listed in error.log file.